### PR TITLE
Fix/gosec errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
 
   audit:
-    name: Go Sec
+    name: Run Go Sec
     runs-on: ubuntu-latest
     env:
       GO111MODULE: on

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,9 +35,13 @@ func init() {
 		tfExtensions[ext] = nil
 	}
 
-	rootCmd.MarkFlagRequired("base-path")
-	rootCmd.MarkFlagRequired("extensions")
+	handleCobraError(rootCmd.MarkFlagRequired("base-path"))
+	handleCobraError(rootCmd.MarkFlagRequired("extensions"))
 
-	rootCmd.MarkFlagDirname("path")
-	rootCmd.MarkFlagFilename("path")
+	handleCobraError(rootCmd.MarkFlagDirname("path"))
+	handleCobraError(rootCmd.MarkFlagFilename("path"))
+}
+
+func handleCobraError(err error) {
+	util.ErrorAndExit("an error occured starting the applicaiton (%s)", err.Error())
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,13 +35,20 @@ func init() {
 		tfExtensions[ext] = nil
 	}
 
-	handleCobraError(rootCmd.MarkFlagRequired("base-path"))
-	handleCobraError(rootCmd.MarkFlagRequired("extensions"))
+	if path == "" {
+		path = "."
+	}
 
-	handleCobraError(rootCmd.MarkFlagDirname("path"))
-	handleCobraError(rootCmd.MarkFlagFilename("path"))
+	if len(*extensions) == 0 {
+		*extensions = []string{".hcl", ".tf"}
+	}
+
+	handleCobraError(rootCmd.MarkPersistentFlagDirname("path"))
+	handleCobraError(rootCmd.MarkPersistentFlagFilename("path"))
 }
 
 func handleCobraError(err error) {
-	util.ErrorAndExit("an error occured starting the applicaiton (%s)", err.Error())
+	if err != nil {
+		util.ErrorAndExit("an error occured starting the applicaiton (%s)", err.Error())
+	}
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -77,6 +77,8 @@ func executeUpdate(cmd *cobra.Command, args []string) {
 		}
 
 		for module, gitVersion := range sourcesInFile {
+			gitVersion := gitVersion
+
 			if gitVersion.LocalVersionString() == "HEAD" && !versionUnversioned {
 				fmt.Printf("skipping: %s (unversioned module, to force versioning re-run with --version-unversioned\n", module)
 				continue

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -115,7 +115,9 @@ func executeUpdate(cmd *cobra.Command, args []string) {
 		}
 
 		if !dryRun {
-			parser.Save()
+			if err := parser.Save(); err != nil {
+				fmt.Fprintf(os.Stderr, "error saving file at %s (%s)", path, err.Error())
+			}
 		}
 	}
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -55,8 +55,7 @@ func executeUpdate(cmd *cobra.Command, args []string) {
 	var version *semver.Version
 	if specifiedVersion != "" {
 		if version, _ = semver.NewVersion(specifiedVersion); version == nil {
-			fmt.Fprintf(os.Stderr, "specified version string %s is invalid\n", specifiedVersion)
-			os.Exit(1)
+			util.ErrorAndExit("specified version string %s is invalid\n", specifiedVersion)
 		}
 	}
 

--- a/internal/hcl.go
+++ b/internal/hcl.go
@@ -118,8 +118,6 @@ func (p *HclParser) Save() error {
 		return err
 	}
 
-	defer file.Close()
-
 	output := bufio.NewWriter(file)
 	defer output.Flush()
 
@@ -129,7 +127,7 @@ func (p *HclParser) Save() error {
 		return err
 	}
 
-	return nil
+	return file.Close()
 }
 
 // SetSourceVersion updates the block source in memory to change the given sources' version to the version specified.

--- a/internal/hcl.go
+++ b/internal/hcl.go
@@ -148,7 +148,7 @@ func (p *HclParser) UpdateBlockSource(source *GitSource) {
 }
 
 func parseHcl(filePath string) (*hclwrite.File, []error) {
-	raw, err := ioutil.ReadFile(filePath)
+	raw, err := ioutil.ReadFile(filepath.Clean(filePath))
 	if err != nil {
 		return nil, []error{err}
 	}

--- a/internal/hcl.go
+++ b/internal/hcl.go
@@ -82,7 +82,8 @@ func (p *HclParser) FindGitSources(includeRemote bool) (map[string]GitSource, er
 			return nil, err
 		}
 
-		if queryString.Has("ref") {
+		// queryString.Has exists (url.Values.Has) but GoSec can't see it for some reason and fails?
+		if _, ok := queryString["ref"]; ok {
 			sv, _ := semver.NewVersion(queryString.Get("ref"))
 			gitSource.localVersion = sv
 			queryString.Del("ref")

--- a/util/util.go
+++ b/util/util.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -58,4 +59,10 @@ func FindTerraformFiles(basePath string, extensions *FileExtensions) ([]string, 
 	})
 
 	return paths, err
+}
+
+// ErrorAndExit writes the given message to stderr and exits the program.
+func ErrorAndExit(msg string, params ...interface{}) {
+	fmt.Fprintf(os.Stderr, fmt.Sprintf("%s\n", msg), params...)
+	os.Exit(1)
 }


### PR DESCRIPTION
Fixes:

```
 Golang errors in file: [/github/workspace/internal/hcl.go]:

  > [line 85 : column 18] - queryString.Has undefined (type "net/url".Values has no field or method Has)



[/github/workspace/internal/hcl.go:151] - G304 (CWE-22): Potential file inclusion via variable (Confidence: HIGH, Severity: MEDIUM)
    150: func parseHcl(filePath string) (*hclwrite.File, []error) {
  > 151: 	raw, err := ioutil.ReadFile(filePath)
    152: 	if err != nil {



[/github/workspace/cmd/update.go:112] - G601 (CWE-118): Implicit memory aliasing in for loop. (Confidence: MEDIUM, Severity: MEDIUM)
    111: 			gitVersion.SetSourceVersion(targetVersion)
  > 112: 			parser.UpdateBlockSource(&gitVersion)
    113: 		}



[/github/workspace/internal/hcl.go:121] - G307 (CWE-703): Deferring unsafe method "Close" on type "*os.File" (Confidence: HIGH, Severity: MEDIUM)
    120: 
  > 121: 	defer file.Close()
    122: 



[/github/workspace/cmd/update.go:116] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    115: 		if !dryRun {
  > 116: 			parser.Save()
    117: 		}



[/github/workspace/cmd/root.go:42] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    41: 	rootCmd.MarkFlagDirname("path")
  > 42: 	rootCmd.MarkFlagFilename("path")
    43: }



[/github/workspace/cmd/root.go:41] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    40: 
  > 41: 	rootCmd.MarkFlagDirname("path")
    42: 	rootCmd.MarkFlagFilename("path")



[/github/workspace/cmd/root.go:39] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    38: 	rootCmd.MarkFlagRequired("base-path")
  > 39: 	rootCmd.MarkFlagRequired("extensions")
    40: 



[/github/workspace/cmd/root.go:38] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    37: 
  > 38: 	rootCmd.MarkFlagRequired("base-path")
    39: 	rootCmd.MarkFlagRequired("extensions")

```
[source](https://github.com/jbrailsford/tfmodref/runs/3847628466?check_suite_focus=true)