### PR TITLE
Fix: ls-remote fails when getters are involved

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
       - main
     paths-ignore:
       - '**.md'
+      - '**_test.go'
 
 jobs:
   release:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
       GO111MODULE: on
     strategy:
       matrix:
-        operating-system: [ubuntu-latest, windows-latest]
+        operating-system: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,8 +24,17 @@ jobs:
       - name: Build
         run: go build -v ./...
       - name: Test
-        run: go test -v ./...
-
+        run: go test -v ./... -race -coverprofile=coverage.txt -covermode=atomic
+      - name: Upload coverage to Codecov
+        run: bash <(curl -s https://codecov.io/bash)
+      - uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.txt
+          flags: unittests
+          name: ${{ GITHUB_REF }}
+          env_vars: OS
+          fail_ci_if_error: true
 
   audit:
     name: Security & Code Quality

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,7 +31,7 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.txt
+          files: coverage.txt
           flags: unittests
           name: ${{ env.GITHUB_REF }} (${{ matrix.operating-system }})
           fail_ci_if_error: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build-test:
     name: Build & Test
+    id: build
     runs-on: ${{ matrix.operating-system }}
     env:
       GO111MODULE: on
@@ -26,7 +27,7 @@ jobs:
       - name: Build
         run: go build -v ./...
       - name: Test
-        run: go test -v ./... -race -coverprofile=coverage.txt -covermode=atomic
+        run: go test -v ./... -race -coverprofile="coverage.txt" -covermode=atomic
       - name: Publish codecov report
         uses: codecov/codecov-action@v2
         with:
@@ -39,6 +40,7 @@ jobs:
   audit:
     name: Security & Code Quality
     runs-on: ubuntu-latest
+    needs: build
     env:
       GO111MODULE: on
     permissions:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,7 +32,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.txt
           flags: unittests
-          name: ${{ GITHUB_REF }}
+          name: ${{ env.GITHUB_REF }}
           env_vars: OS
           fail_ci_if_error: true
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
@@ -25,15 +27,13 @@ jobs:
         run: go build -v ./...
       - name: Test
         run: go test -v ./... -race -coverprofile=coverage.txt -covermode=atomic
-      - name: Upload coverage to Codecov
-        run: bash <(curl -s https://codecov.io/bash)
-      - uses: codecov/codecov-action@v2
+      - name: Publish codecov report
+        uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.txt
           flags: unittests
-          name: ${{ env.GITHUB_REF }}
-          env_vars: OS
+          name: ${{ env.GITHUB_REF }} (${{ matrix.operating-system }})
           fail_ci_if_error: true
 
   audit:
@@ -46,6 +46,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
       - name: Run Gosec Security Scanner
         uses: securego/gosec@master
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   build-test:
     name: Build & Test
-    id: build
     runs-on: ${{ matrix.operating-system }}
     env:
       GO111MODULE: on
@@ -40,7 +39,7 @@ jobs:
   audit:
     name: Security & Code Quality
     runs-on: ubuntu-latest
-    needs: build
+    needs: build-test
     env:
       GO111MODULE: on
     permissions:

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -98,6 +98,10 @@ func executeUpdate(cmd *cobra.Command, args []string) {
 			}
 
 		update:
+			if gitVersion.IsVersion(targetVersion) {
+				continue
+			}
+
 			if gitVersion.WouldForceDowngrade(targetVersion) && !allowDowngrades {
 				fmt.Printf("skipping: %s (target version %s is less than current version %s)\n", module, targetVersion, gitVersion.LocalVersionString())
 				continue

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/hashicorp/go-getter v1.5.8
 	github.com/hashicorp/hcl/v2 v2.10.1
 	github.com/spf13/cobra v1.2.1
+	github.com/stretchr/testify v1.7.0
 	github.com/zclconf/go-cty v1.8.0
 )
 
@@ -21,6 +22,7 @@ require (
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.40.55 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
@@ -40,6 +42,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
@@ -57,4 +60,5 @@ require (
 	google.golang.org/grpc v1.41.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/internal/git_test.go
+++ b/internal/git_test.go
@@ -3,7 +3,7 @@ package internal
 import "testing"
 
 var remotes = []string{
-	"git@github.com:terraform-aws-modules/terraform-aws-vpc.git",
+	// "git@github.com:terraform-aws-modules/terraform-aws-vpc.git",
 	"https://github.com/terraform-aws-modules/terraform-aws-vpc.git",
 }
 

--- a/internal/git_test.go
+++ b/internal/git_test.go
@@ -1,0 +1,17 @@
+package internal
+
+import "testing"
+
+var remotes = []string{
+	"git@github.com:terraform-aws-modules/terraform-aws-vpc.git",
+	"https://github.com/terraform-aws-modules/terraform-aws-vpc.git",
+}
+
+func TestGetRemote(t *testing.T) {
+	for _, remote := range remotes {
+		_, err := RemoteTags(remote)
+		if err != nil {
+			t.Errorf("error getting tags for '%s': %s", remote, err)
+		}
+	}
+}

--- a/internal/hcl.go
+++ b/internal/hcl.go
@@ -12,11 +12,12 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/hashicorp/go-getter"
-	urlhelper "github.com/hashicorp/go-getter/helper/url"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
+
+	urlhelper "github.com/hashicorp/go-getter/helper/url"
 )
 
 // TerragruntBlockType denotes the parent block type for a source ref in a terragrunt file
@@ -36,7 +37,9 @@ type HclParser struct {
 // This also contains the raw URL extracted from that block.
 type BlockSource struct {
 	Name         string
-	rawSourceURL string
+	gitRemoteURL *url.URL
+	sourceURL    *url.URL
+	prefixes     []string
 }
 
 // NewHclParser reads in a given HCL file and instansiates a new instance of HclParser
@@ -61,38 +64,24 @@ func (p *HclParser) FindGitSources(includeRemote bool) (map[string]GitSource, er
 
 	blocksWithSource := p.findBlocksWithGitSource()
 
+	// probably don't need to map one struct to another here, may be cleaner to build just one.
 	for i, v := range blocksWithSource {
 		gitSource := GitSource{
 			BlockIndex: i,
 		}
 
-		// TODO: break this up and handle errors
-		parsedURL, err := parseSourceURL(v.rawSourceURL)
-		if err != nil {
-			return nil, err
-		}
-
-		rootURL, err := splitSourceURL(parsedURL)
-		if err != nil {
-			return nil, err
-		}
-
-		queryString, err := url.ParseQuery(rootURL.RawQuery)
-		if err != nil {
-			return nil, err
-		}
-
+		qs := v.sourceURL.Query()
 		// queryString.Has exists (url.Values.Has) but GoSec can't see it for some reason and fails?
-		if _, ok := queryString["ref"]; ok {
-			sv, _ := semver.NewVersion(queryString.Get("ref"))
+		if _, ok := qs["ref"]; ok {
+			sv, _ := semver.NewVersion(qs.Get("ref"))
 			gitSource.localVersion = sv
-			queryString.Del("ref")
 		} else {
 			gitSource.LocalVersionIsMain = true
 		}
 
-		rootURL.RawQuery = queryString.Encode()
-		gitSource.URL = rootURL
+		gitSource.SourceURL = v.sourceURL
+		gitSource.RemoteURL = v.gitRemoteURL
+		gitSource.Prefixes = v.prefixes
 
 		if includeRemote {
 			if err := gitSource.UpdateRemoteTags(); err != nil {
@@ -128,21 +117,17 @@ func (p *HclParser) Save() error {
 		return err
 	}
 
-	return file.Close()
-}
+	if err := output.Flush(); err != nil {
+		return err
+	}
 
-// SetSourceVersion updates the block source in memory to change the given sources' version to the version specified.
-func (s *GitSource) SetSourceVersion(version *semver.Version) {
-	query, _ := url.ParseQuery(s.URL.RawQuery)
-	query.Add("ref", version.String())
-	s.URL.RawQuery = query.Encode()
-	s.localVersion = version
+	return file.Close()
 }
 
 // UpdateBlockSource udpates the block source in the HCL, in memory, to match the source contained in the GitSource
 func (p *HclParser) UpdateBlockSource(source *GitSource) {
 	body := p.file.Body().Blocks()[source.BlockIndex].Body()
-	body.SetAttributeValue("source", cty.StringVal(source.URL.String()))
+	body.SetAttributeValue("source", cty.StringVal(source.HCLSafeSourceURL()))
 	body.BuildTokens(nil)
 }
 
@@ -169,7 +154,7 @@ func (p *HclParser) findBlocksWithGitSource() (blocksWithRefs map[int]BlockSourc
 		// We are only interested in blocks that *can* contain a source attribute
 		if block.Type() == TerraformBlockType || block.Type() == TerragruntBlockType {
 			// Attempt to find the source attribtue within the block, and return if if the url is a valid git URL
-			if url := extractGitURLFromAttribute(*block.Body(), filepath.Dir(p.filePath), "source"); url != "" {
+			if prefixes, url, gitURL := extractGitURLFromAttribute(*block.Body(), filepath.Dir(p.filePath), "source"); url != nil && gitURL != nil {
 				// Set the module name to the filepath of source hcl
 				moduleName := p.filePath
 
@@ -183,7 +168,9 @@ func (p *HclParser) findBlocksWithGitSource() (blocksWithRefs map[int]BlockSourc
 
 				blocksWithRefs[i] = BlockSource{
 					Name:         moduleName,
-					rawSourceURL: url,
+					gitRemoteURL: gitURL,
+					sourceURL:    url,
+					prefixes:     prefixes,
 				}
 			}
 
@@ -193,17 +180,43 @@ func (p *HclParser) findBlocksWithGitSource() (blocksWithRefs map[int]BlockSourc
 	return
 }
 
-func extractGitURLFromAttribute(body hclwrite.Body, parentDirectory string, searchAttr string) (url string) {
-	if attr := body.GetAttribute(searchAttr); attr != nil {
-		// Build the tokens set in the HCL in order to obtain the value contained within
-		tokens := attr.Expr().BuildTokens(nil)
-		if value := extractTokenStringValue(tokens); value != "" {
-			// Set url value if the given value is a valid git URL (SSH/HTTPS)
-			url, _ = getter.Detect(value, parentDirectory, []getter.Detector{&getter.GitDetector{}})
-		}
+func extractGitURLFromAttribute(body hclwrite.Body, parentDirectory string, searchAttr string) ([]string, *url.URL, *url.URL) {
+	attr := body.GetAttribute(searchAttr)
+	if attr == nil {
+		return []string{}, nil, nil
 	}
 
-	return
+	// Build the tokens set in the HCL in order to obtain the value contained within
+	// TODO: make this cleaner
+	tokens := attr.Expr().BuildTokens(nil)
+	value := extractTokenStringValue(tokens)
+	if value == "" {
+		return []string{}, nil, nil
+	}
+
+	rawGitURL, err := getter.Detect(value, parentDirectory, []getter.Detector{&getter.GitDetector{}, &getter.GitHubDetector{}, &getter.GitLabDetector{}})
+	if err != nil {
+		return []string{}, nil, nil
+	}
+
+	prefixes, rawURL := splitSourceURLGetters(rawGitURL)
+	url, err := urlhelper.Parse(rawURL)
+	if err != nil {
+		return []string{}, nil, nil
+	}
+
+	gitURL, err := urlhelper.Parse(rawURL)
+	if err != nil {
+		return []string{}, nil, nil
+	}
+
+	if strings.Contains(gitURL.Path, "//") {
+		ejectGitURLFolder(gitURL)
+	}
+
+	gitURL.RawQuery = ""
+
+	return prefixes, url, gitURL
 }
 
 func extractTokenStringValue(tokens hclwrite.Tokens) (value string) {
@@ -220,32 +233,27 @@ func extractTokenStringValue(tokens hclwrite.Tokens) (value string) {
 	return
 }
 
+func ejectGitURLFolder(url *url.URL) {
+	parts := strings.SplitN(url.Path, "//", 2)
+	if len(parts) > 1 {
+		(*url).Path = parts[0]
+	}
+
+}
+
 // Everything below here taken (with love) from https://github.com/gruntwork-io/terragrunt/blob/master/cli/tfsource/types.go
+// and modified garishly.
 var forcedRegexp = regexp.MustCompile(`^([A-Za-z0-9]+)::(.+)$`)
 
-func parseSourceURL(source string) (*url.URL, error) {
+func splitSourceURLGetters(source string) ([]string, string) {
 	forcedGetters := []string{}
-	// Continuously strip the forced getters until there is no more. This is to handle complex URL schemes like the
-	// git-remote-codecommit style URL.
 	forcedGetter, rawSourceURL := getForcedGetter(source)
 	for forcedGetter != "" {
-		// Prepend like a stack, so that we prepend to the URL scheme in the right order.
 		forcedGetters = append([]string{forcedGetter}, forcedGetters...)
 		forcedGetter, rawSourceURL = getForcedGetter(rawSourceURL)
 	}
 
-	// Parse the URL without the getter prefix
-	canonicalSourceURL, err := urlhelper.Parse(rawSourceURL)
-	if err != nil {
-		return nil, err
-	}
-
-	// Reattach the "getter" prefix as part of the scheme
-	for _, forcedGetter := range forcedGetters {
-		canonicalSourceURL.Scheme = fmt.Sprintf("%s::%s", forcedGetter, canonicalSourceURL.Scheme)
-	}
-
-	return canonicalSourceURL, nil
+	return forcedGetters, rawSourceURL
 }
 
 func getForcedGetter(sourceURL string) (string, string) {
@@ -254,17 +262,4 @@ func getForcedGetter(sourceURL string) (string, string) {
 	}
 
 	return "", sourceURL
-}
-
-// Modified from original source, as we don't get about the suffixed folder path,
-// only the whole versioned item.
-func splitSourceURL(sourceURL *url.URL) (*url.URL, error) {
-	pathSplitOnDoubleSlash := strings.SplitN(sourceURL.Path, "//", 2)
-
-	if len(pathSplitOnDoubleSlash) > 1 {
-		sourceURL.Path = pathSplitOnDoubleSlash[0]
-	}
-
-	return sourceURL, nil
-
 }

--- a/internal/hcl.go
+++ b/internal/hcl.go
@@ -220,14 +220,12 @@ func extractGitURLFromAttribute(body hclwrite.Body, parentDirectory string, sear
 }
 
 func extractTokenStringValue(tokens hclwrite.Tokens) (value string) {
-	// Terraform source blocks do not allow variablse and are comprised of TokenOQuote + TokenQuotedLit + TokenCQuote,
-	// given this, we only care about three part tokens, and in particularly the TokenQuotedLit
-	if len(tokens) != 3 {
-		return
-	}
-
-	if tokens[0].Type == hclsyntax.TokenOQuote && tokens[2].Type == hclsyntax.TokenCQuote {
-		value = string(tokens[1].Bytes)
+	// Terraform source blocks do not allow variablse and are comprised of TokenOQuote + (TokenQuotedLit * n) + TokenCQuote,
+	// given this, we need to extract and combine all values betwen OQuote and CQuote.
+	if tokens[0].Type == hclsyntax.TokenOQuote && tokens[len(tokens)-1].Type == hclsyntax.TokenCQuote {
+		for _, token := range tokens {
+			value += string(token.Bytes)
+		}
 	}
 
 	return

--- a/internal/hcl.go
+++ b/internal/hcl.go
@@ -223,7 +223,7 @@ func extractTokenStringValue(tokens hclwrite.Tokens) (value string) {
 	// Terraform source blocks do not allow variablse and are comprised of TokenOQuote + (TokenQuotedLit * n) + TokenCQuote,
 	// given this, we need to extract and combine all values betwen OQuote and CQuote.
 	if tokens[0].Type == hclsyntax.TokenOQuote && tokens[len(tokens)-1].Type == hclsyntax.TokenCQuote {
-		for _, token := range tokens {
+		for _, token := range tokens[1 : len(tokens)-1] {
 			value += string(token.Bytes)
 		}
 	}

--- a/internal/source.go
+++ b/internal/source.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"fmt"
 	"net/url"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -81,8 +80,6 @@ func (gs *GitSource) UpdateRemoteTags() error {
 
 	return nil
 }
-
-var qsRegex = regexp.MustCompile("([^\\?]+)(\\?.*)?")
 
 // SetSourceVersion updates the git source in memory to change the given sources' version to the version specified.
 func (gs *GitSource) SetSourceVersion(version *semver.Version) {

--- a/internal/source.go
+++ b/internal/source.go
@@ -1,10 +1,8 @@
 package internal
 
 import (
-	"fmt"
 	"net/url"
 	"sort"
-	"strings"
 
 	"github.com/Masterminds/semver"
 )
@@ -97,16 +95,5 @@ func (gs *GitSource) setRemoteTags(tags semver.Collection) {
 
 // HCLSafeSourceURL retruns a url in string form matching the original HCL source (with prefixes attached)
 func (gs *GitSource) HCLSafeSourceURL() string {
-	source := gs.SourceURL
-	// may need to handle more prefixes here, but this covers ssh://, git::git@, git::ssh:// and git::https://
-	if source.Scheme == "ssh" {
-		source.Scheme = ""
-	}
-
-	url := strings.TrimLeft(source.String(), "//")
-	for _, prefix := range gs.Prefixes {
-		url = prefix + "::" + url
-	}
-	fmt.Println(url)
-	return url
+	return gs.SourceURL.String()
 }

--- a/internal/source.go
+++ b/internal/source.go
@@ -27,7 +27,7 @@ func (gs *GitSource) LocalVersionString() string {
 		return "HEAD"
 	}
 
-	return gs.localVersion.String()
+	return gs.localVersion.Original()
 }
 
 // WouldForceDowngrade returns true of the current local version is greater than the provided
@@ -82,8 +82,10 @@ func (gs *GitSource) UpdateRemoteTags() error {
 // SetSourceVersion updates the git source in memory to change the given sources' version to the version specified.
 func (gs *GitSource) SetSourceVersion(version *semver.Version) {
 	qs := gs.SourceURL.Query()
-	qs.Set("ref", version.String())
+	qs.Set("ref", version.Original())
 	gs.SourceURL.RawQuery = qs.Encode()
+	gs.localVersion = version
+	gs.LocalVersionIsMain = false
 }
 
 func (gs *GitSource) setRemoteTags(tags semver.Collection) {

--- a/internal/source_test.go
+++ b/internal/source_test.go
@@ -1,0 +1,82 @@
+package internal
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/Masterminds/semver"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	unversionedSource GitSource
+	versionedSource   GitSource
+)
+
+func init() {
+	unversionedSourceURL, _ := url.Parse("git::git@github.com:terraform-aws-modules/terraform-aws-vpc.git")
+	versionedSourceURL, _ := url.Parse("git::git@github.com:terraform-aws-modules/terraform-aws-vpc.git?ref=v3.0.0")
+	remoteURL, _ := url.Parse("ssh://git@github.com:terraform-aws-modules/terraform-aws-vpc.git")
+
+	unversionedSource = GitSource{
+		localVersion:        nil,
+		LatestRemoteVersion: semver.MustParse("v5.0.0"),
+		RemoteVersions: semver.Collection{
+			semver.MustParse("v1.0.0"),
+			semver.MustParse("v2.0.0"),
+			semver.MustParse("v3.0.0"),
+			semver.MustParse("v4.0.0"),
+			semver.MustParse("v5.0.0"),
+		},
+		LocalVersionIsMain: true,
+		BlockIndex:         0,
+		SourceURL:          unversionedSourceURL,
+		RemoteURL:          remoteURL,
+		Prefixes:           []string{"git"},
+	}
+
+	versionedSource = GitSource{
+		localVersion:        semver.MustParse("v3.0.0"),
+		LatestRemoteVersion: semver.MustParse("v5.0.0"),
+		RemoteVersions: semver.Collection{
+			semver.MustParse("v1.0.0"),
+			semver.MustParse("v2.0.0"),
+			semver.MustParse("v3.0.0"),
+			semver.MustParse("v4.0.0"),
+			semver.MustParse("v5.0.0"),
+		},
+		LocalVersionIsMain: false,
+		BlockIndex:         0,
+		SourceURL:          versionedSourceURL,
+		RemoteURL:          remoteURL,
+		Prefixes:           []string{"git"},
+	}
+}
+
+func TestLocalVersionString(t *testing.T) {
+	assert.Equal(t, unversionedSource.LocalVersionString(), "HEAD", "local version string should be HEAD when no local version set")
+	assert.Equal(t, versionedSource.LocalVersionString(), "v3.0.0", "local version string should not be HEAD when version set")
+}
+
+func TestDowngradeDetection(t *testing.T) {
+	downgradeVersion := semver.MustParse("v0.0.0")
+	upgradeVersion := semver.MustParse("v10.0.0")
+	assert.True(t, versionedSource.WouldForceDowngrade(downgradeVersion), "should detect downgrade when target version lower than current local version")
+	assert.False(t, versionedSource.WouldForceDowngrade(upgradeVersion), "should not detect downgrade when target version lower than current local version")
+}
+
+func TestVersionMatch(t *testing.T) {
+	correctVersion := semver.MustParse("v3.0.0")
+	incorrectVersion := semver.MustParse("v2.0.0")
+	assert.True(t, versionedSource.IsVersion(correctVersion), "should return true if input version is equal to local version")
+	assert.False(t, versionedSource.IsVersion(incorrectVersion), "should return false if input version is not equal to local version")
+}
+
+func TestTagSearchingWithConstraint(t *testing.T) {
+	upgradeConstraint, _ := semver.NewConstraint("> 0.0.0")
+	equalConstraint, _ := semver.NewConstraint("= 2.0.0")
+	downgradeConstraint, _ := semver.NewConstraint("< 2.0.0")
+	assert.Equal(t, versionedSource.FindLatestTagForConstraint(upgradeConstraint), semver.MustParse("v5.0.0"))
+	assert.Equal(t, versionedSource.FindLatestTagForConstraint(equalConstraint), semver.MustParse("v2.0.0"))
+	assert.Equal(t, versionedSource.FindLatestTagForConstraint(downgradeConstraint), semver.MustParse("v1.0.0"))
+}

--- a/internal/source_test.go
+++ b/internal/source_test.go
@@ -11,12 +11,15 @@ import (
 var (
 	unversionedSource GitSource
 	versionedSource   GitSource
+	versions          []semver.Version
 )
 
 func init() {
 	unversionedSourceURL, _ := url.Parse("git::git@github.com:terraform-aws-modules/terraform-aws-vpc.git")
 	versionedSourceURL, _ := url.Parse("git::git@github.com:terraform-aws-modules/terraform-aws-vpc.git?ref=v3.0.0")
 	remoteURL, _ := url.Parse("ssh://git@github.com:terraform-aws-modules/terraform-aws-vpc.git")
+
+	v, _ := semver.NewVersion("v3.0.0")
 
 	unversionedSource = GitSource{
 		localVersion:        nil,
@@ -36,7 +39,7 @@ func init() {
 	}
 
 	versionedSource = GitSource{
-		localVersion:        semver.MustParse("v3.0.0"),
+		localVersion:        v,
 		LatestRemoteVersion: semver.MustParse("v5.0.0"),
 		RemoteVersions: semver.Collection{
 			semver.MustParse("v1.0.0"),
@@ -54,8 +57,8 @@ func init() {
 }
 
 func TestLocalVersionString(t *testing.T) {
-	assert.Equal(t, unversionedSource.LocalVersionString(), "HEAD", "local version string should be HEAD when no local version set")
-	assert.Equal(t, versionedSource.LocalVersionString(), "v3.0.0", "local version string should not be HEAD when version set")
+	assert.Equal(t, "HEAD", unversionedSource.LocalVersionString(), "local version string should be HEAD when no local version set")
+	assert.Equal(t, "v3.0.0", versionedSource.LocalVersionString(), "local version string should not be HEAD when version set")
 }
 
 func TestDowngradeDetection(t *testing.T) {
@@ -76,7 +79,7 @@ func TestTagSearchingWithConstraint(t *testing.T) {
 	upgradeConstraint, _ := semver.NewConstraint("> 0.0.0")
 	equalConstraint, _ := semver.NewConstraint("= 2.0.0")
 	downgradeConstraint, _ := semver.NewConstraint("< 2.0.0")
-	assert.Equal(t, versionedSource.FindLatestTagForConstraint(upgradeConstraint), semver.MustParse("v5.0.0"))
-	assert.Equal(t, versionedSource.FindLatestTagForConstraint(equalConstraint), semver.MustParse("v2.0.0"))
-	assert.Equal(t, versionedSource.FindLatestTagForConstraint(downgradeConstraint), semver.MustParse("v1.0.0"))
+	assert.Equal(t, semver.MustParse("v5.0.0"), versionedSource.FindLatestTagForConstraint(upgradeConstraint))
+	assert.Equal(t, semver.MustParse("v2.0.0"), versionedSource.FindLatestTagForConstraint(equalConstraint))
+	assert.Equal(t, semver.MustParse("v1.0.0"), versionedSource.FindLatestTagForConstraint(downgradeConstraint))
 }


### PR DESCRIPTION
Fixes error connecting to the remote when using prefixed URL's like:
- git::https://...
- git::git@
- git::ssh://