### PR TITLE
Tests: Utilities 

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,16 +31,17 @@ func init() {
 	extensions := rootCmd.PersistentFlags().StringSliceP("extensions", "e", []string{".hcl", ".tf"}, "file extensions of files to search in for references")
 
 	tfExtensions = make(util.FileExtensions)
+
+	if len(*extensions) == 0 {
+		*extensions = []string{".hcl", ".tf"}
+	}
+
 	for _, ext := range *extensions {
 		tfExtensions[ext] = nil
 	}
 
 	if path == "" {
 		path = "."
-	}
-
-	if len(*extensions) == 0 {
-		*extensions = []string{".hcl", ".tf"}
 	}
 
 	handleCobraError(rootCmd.MarkPersistentFlagDirname("path"))

--- a/util/util.go
+++ b/util/util.go
@@ -24,7 +24,7 @@ func (f *FileExtensions) Contains(extension string) bool {
 // separated string.
 func (f *FileExtensions) AsCommaSeparatedString() (s string) {
 	for k := range *f {
-		s = fmt.Sprintf("%s, ", k)
+		s = fmt.Sprintf("%s%s, ", s, k)
 	}
 
 	s = strings.TrimRight(s, ", ")

--- a/util/util.go
+++ b/util/util.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -22,14 +23,19 @@ func (f *FileExtensions) Contains(extension string) bool {
 
 // AsCommaSeparatedString returns all keys in the FileExtensions map in a comma
 // separated string.
-func (f *FileExtensions) AsCommaSeparatedString() (s string) {
+func (f *FileExtensions) AsCommaSeparatedString() string {
+	keys := make([]string, len(*f))
+
+	// Could use append here, but this comes out slightly more efficient.
+	i := 0
 	for k := range *f {
-		s = fmt.Sprintf("%s%s, ", s, k)
+		keys[i] = k
+		i++
 	}
 
-	s = strings.TrimRight(s, ", ")
+	sort.Strings(keys)
 
-	return
+	return strings.Join(keys, ", ")
 }
 
 // FindTerraformFiles walks the current directory and finds files matching

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,38 @@
+package util
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var extensions = FileExtensions{
+	".hcl": nil,
+	".tf":  nil,
+}
+
+func TestFileExtensionsContains(t *testing.T) {
+	assert.True(t, extensions.Contains("hcl"), "validate FileExtensions contains value")
+}
+
+func TestFileExtensionsToCsvConversion(t *testing.T) {
+	assert.Equal(t, ".hcl, .tf", extensions.AsCommaSeparatedString(), "validate FileExtensions can be converted to a csv string")
+}
+
+func TestErrorAndExit(t *testing.T) {
+	if os.Getenv("TEST_EXIT") == "1" {
+		ErrorAndExit("testing")
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestErrorAndExit")
+	cmd.Env = append(os.Environ(), "TEST_EXIT=1")
+	err := cmd.Run()
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+
+	t.Fatalf("process ran with err %v, want exit status 1", err)
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -14,7 +14,7 @@ var extensions = FileExtensions{
 }
 
 func TestFileExtensionsContains(t *testing.T) {
-	assert.True(t, extensions.Contains("hcl"), "validate FileExtensions contains value")
+	assert.True(t, extensions.Contains(".hcl"), "validate FileExtensions contains value")
 }
 
 func TestFileExtensionsToCsvConversion(t *testing.T) {


### PR DESCRIPTION
Adds initial utility tests, excluding `FindTerraformFiles` as that will be incorporated with the hcl tests.